### PR TITLE
Upgrade the evaluator model to GPT-4.1 for better performance AND lower cost

### DIFF
--- a/src/agisdk/REAL/browsergym/webclones/evaluate.py
+++ b/src/agisdk/REAL/browsergym/webclones/evaluate.py
@@ -4,7 +4,7 @@ import jmespath
 import json
 
 class WebCloneEvaluator:
-    def __init__(self, task_config: Dict[str, Any], llm: str = "gpt-4o"):
+    def __init__(self, task_config: Dict[str, Any], llm: str = "gpt-4.1"):
         """
         Initializes the evaluator with an optional LLM instance for fuzzy matching.
         


### PR DESCRIPTION
We upgrade the evaluator model, for lower token cost, and more accurate fuzzy matching

This pull request updates the default LLM version used in the `WebCloneEvaluator` class to a newer version.

* [`src/agisdk/REAL/browsergym/webclones/evaluate.py`](diffhunk://#diff-bab61cbcc1698d9bb56f7e79c6503627d2202883d9e0e80eeca8a6aba8ebffa0L7-R7): Updated the default `llm` parameter in the `WebCloneEvaluator` class from `"gpt-4o"` to `"gpt-4.1"`.