### PR TITLE
Fixing the omnizon-5 test, for the correct monitor item "KTC 24 inch 1500R Curved Gaming Monitor"

### DIFF
--- a/src/agisdk/REAL/browsergym/webclones/tasks/omnizon-5.json
+++ b/src/agisdk/REAL/browsergym/webclones/tasks/omnizon-5.json
@@ -1,6 +1,6 @@
 {
   "id": "omnizon-5",
-  "goal": "Search for the \"KTC 24-inch 1500R Curved Gaming Monitor,\" click on it, and display the specifications from its product page.",
+  "goal": "Search for the \"KTC 24 inch 1500R Curved Gaming Monitor\" click on it, and display the specifications from its product page.",
   "website": {
     "id": "omnizon",
     "name": "Omnizon",
@@ -15,7 +15,7 @@
     {
       "type": "llm_boolean",
       "expected_value": true,
-      "rubric": "Does the answer list multiple specifications of the KTC 24-inch 1500R Curved Gaming Monitor, such as size, resolution, refresh rate, or other technical details?"
+      "rubric": "Does the answer list multiple specifications of the KTC 24 inch 1500R Curved Gaming Monitor, such as size, resolution, refresh rate, or other technical details?"
     }
   ],
   "points": 1,


### PR DESCRIPTION
This is for #7 

This pull request includes minor text adjustments to the task definition and rubric in the `omnizon-5.json` file to standardize the formatting of the product name by removing the hyphen from "24-inch."

Changes to task definition and rubric:

* Updated the `goal` field to replace "KTC 24-inch" with "KTC 24 inch" for consistency in the product name formatting. (`src/agisdk/REAL/browsergym/webclones/tasks/omnizon-5.json`, [src/agisdk/REAL/browsergym/webclones/tasks/omnizon-5.jsonL3-R3](diffhunk://#diff-0de6c053901a88d7da4ca08d5c3698e13eb751c4ecb8e1158460527527d30849L3-R3))
* Updated the `rubric` field to match the standardized product name formatting by removing the hyphen from "24-inch." (`src/agisdk/REAL/browsergym/webclones/tasks/omnizon-5.json`, [src/agisdk/REAL/browsergym/webclones/tasks/omnizon-5.jsonL18-R18](diffhunk://#diff-0de6c053901a88d7da4ca08d5c3698e13eb751c4ecb8e1158460527527d30849L18-R18))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated phrasing in user-facing instructions and evaluation criteria to use "24 inch" instead of "24-inch".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->