### PR TITLE
[ziloft] Clearer goal instruction for ziloft-2

### DIFF
--- a/src/agisdk/REAL/browsergym/webclones/tasks/zilloft-2.json
+++ b/src/agisdk/REAL/browsergym/webclones/tasks/zilloft-2.json
@@ -1,6 +1,6 @@
 {
   "id": "zilloft-2",
-  "goal": "Filter the listings in San Francisco to show only homes with 3 bedrooms and 2 bathrooms. How many listings are displayed?",
+  "goal": "Filter the listings in San Francisco to show only homes with exactly 3 bedrooms and 2 bathrooms. How many listings are displayed?",
   "website": {
     "id": "zilloft",
     "name": "Zilloft",


### PR DESCRIPTION
Currently ziloft-2 goal is vague. It could mean 3 or more bedrooms, or exactly 3 bedrooms.
The evaluation, is matching strictly against 16 listing (or 3 exact bedrooms)

As this is vague, AI's will prefer to report for 3 or more instead of 3 exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated task goal description to clarify that the filter should show homes with exactly 3 bedrooms and 2 bathrooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->