### PR TITLE
Fix issues with running starter code

### DIFF
--- a/src/agisdk/REAL/browsergym/webclones/task_config.py
+++ b/src/agisdk/REAL/browsergym/webclones/task_config.py
@@ -80,7 +80,7 @@ class TaskConfig:
             self.id = self.config_json.get('id', '')
         else:
             # It's an ID
-            self.id = id_or_path
+            self.id = input_source
             self.config_json = self.load_from_id(self.id)
         
         # Validate configuration first


### PR DESCRIPTION
Had issues with running the starter code, and it seems to trace back to this [commit](https://github.com/agi-inc/agisdk/commit/ab807d68ffea8248cd821da9806b2b22716afb93), which introduces the `id_or_path` variable, but is not defined in the constructor. Changed it to `input_source`, which appears to fix locally.

I suppose `is_path` is not necessarily needed in this case, then, but decided to leave it alone for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where task IDs were not correctly assigned when loading configurations, ensuring more reliable task identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->